### PR TITLE
Show JSON Path in Footer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,6 @@ var screenView = require('./views/screen');
 var listView   = require('./views/list');
 
 module.exports = function(data, input, output) {
-  var list = listView(new Value(data, null), new Session(), screenView(input, output));
+  var list = listView(new Value(data, null, []), new Session(), screenView(input, output));
   list.focus();
 };

--- a/src/value.js
+++ b/src/value.js
@@ -145,7 +145,7 @@ function JsonValue(val, key, parents) {
     }
 
     if (this.isArray()) {
-      return new JsonValue(val[index], index, parents.concat([index]));
+      return new JsonValue(val[index], index, parents.concat(['[' + index + ']']));
     }
 
     var keys = Object.keys(val);

--- a/src/value.js
+++ b/src/value.js
@@ -4,8 +4,10 @@
  * Represents a JSON value
  *
  * @param {*} val
+ * @param {String} key
+ * @param {String[]} parents
  */
-function JsonValue(val, key) {
+function JsonValue(val, key, parents) {
   var state = {};
 
   /**
@@ -37,6 +39,15 @@ function JsonValue(val, key) {
    */
   this.getKey = function() {
     return key;
+  };
+
+  /**
+   * Gets the list of parent keys
+   *
+   * @return {String[]}
+   */
+  this.getParents = function() {
+    return parents;
   };
 
   /**
@@ -134,11 +145,11 @@ function JsonValue(val, key) {
     }
 
     if (this.isArray()) {
-      return new JsonValue(val[index], index);
+      return new JsonValue(val[index], index, parents.concat([index]));
     }
 
     var keys = Object.keys(val);
-    return new JsonValue(val[keys[index]], keys[index]);
+    return new JsonValue(val[keys[index]], keys[index], parents.concat([keys[index]]));
   };
 
   /**

--- a/src/views/list.js
+++ b/src/views/list.js
@@ -12,6 +12,7 @@ module.exports = function listView(value, session, parent) {
     tags: true,
     keys: true,
     vi: true,
+    height: '100%-1',
     border: {
       type: 'line',
       fg: 'lightblack'
@@ -23,6 +24,18 @@ module.exports = function listView(value, session, parent) {
     styler: new Styler(session, defaultStyle(session))
   });
 
+  list.path = blessed.box({
+    left: 1,
+    bottom: 0,
+    height: 1,
+    content: 'Path: ' + value.getParents().join('.'),
+    style: { fg: 'white' }
+  });
+
+  if (!value.getParents().length) {
+    list.path.hide();
+  }
+
   list.on('selectValue', function(selected) {
     if (!selected.hasChildren()) {
       return;
@@ -30,8 +43,10 @@ module.exports = function listView(value, session, parent) {
 
     var newList = listView(selected, session, parent);
     newList.key(['escape', 'h'], function() {
+      newList.screen.remove(newList.path);
       parent.remove(newList);
       parent.render();
+      newList.destroy();
       newList.destroy();
     });
 
@@ -46,6 +61,11 @@ module.exports = function listView(value, session, parent) {
   });
 
   parent.append(list);
+  parent.append(list.path);
   parent.render();
+
+  list.screen.render();
+  list.focus();
+
   return list;
 };

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -5,10 +5,10 @@ var blessed = require('blessed');
 module.exports = function(parent) {
   var input = new blessed.Textbox({
     parent: parent,
-    bottom: 0,
     right: 0,
-    width: 50,
+    bottom: 0,
     height: 1,
+    width: 50,
     style: {
       fg: 'white',
       bg: 'lightblack'


### PR DESCRIPTION
Attempt at #6 

Some things are behaving a little quirky still, so still a work in progress. If you happen to search at the same time, search will be above the key.

Things for consideration:

- show or hide by default?
- toggle with a key?
- separate with dots? (pseudo-json path), something prettier, or go for actual json path?
- is there a need to jump to a given path as well? 
- do we want the same clipboard behaviour for paths?

<img width="682" alt="screen shot 2017-05-05 at 8 58 25 pm" src="https://cloud.githubusercontent.com/assets/117682/25769710/a35264c4-31d5-11e7-859f-a3da346ac8a7.png">