### PR TITLE
Allow stdout to be used by other programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ When the application is open, you are in an interactive [blessed](https://github
 `l`: enter (open node)  
 `<Enter>`: enter (open node)  
 `y` or `c`: copy current value to clipboard
+`o`: send current selection to stdout and exit
 `-`: toggle expansion  
 `/`: search for string recursively  
 `*`: search for value under cursor  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can also read from stdin instead of a file:
 
     curl -s https://api.github.com/users/adrianschneider/repos | jsonfui
 
-You can also write to stdout with `o`:
+You can also write to stdout with `Enter`:
 
     # list repos, pick one, view on github
     curl -s https://api.github.com/users/adrianschneider/repos | jsonfui | xargs open
@@ -35,19 +35,18 @@ When the application is open, you are in a vim-style tree viewer.
 
 ### Hotkeys (vim mode)
 
-`j`: down  
-`k`: up  
-`h`: go back/up one level  
-`l`: enter (open node)  
-`<Enter>`: enter (open node)  
+`down`, `j`: down
+`up`, `k`: up
+`left`, `h`: go back/up one level
+`right`, `l`: view child node
+`<Enter>`: send current selection to stdout and exit
 `y` or `c`: copy current value to clipboard
-`o`: send current selection to stdout and exit
-`-`: toggle expansion  
-`/`: search for string recursively  
-`*`: search for value under cursor  
-`n`: next search result at current depth  
-`N`: prev search result at current depth  
-`<space>`: clear highlight  
+`-`: toggle expansion
+`/`: search for string recursively
+`*`: search for value under cursor
+`n`: next search result at current depth
+`N`: prev search result at current depth
+`<space>`: clear highlight
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ You can also read from stdin instead of a file:
 
     curl -s https://api.github.com/users/adrianschneider/repos | jsonfui
 
-When the application is open, you are in an interactive [blessed](https://github.com/chjj/blessed)-powered navigator.
+You can also write to stdout with `o`:
+
+    # list repos, pick one, view on github
+    curl -s https://api.github.com/users/adrianschneider/repos | jsonfui | xargs open
+
+When the application is open, you are in a vim-style tree viewer.
 
 ### Hotkeys (vim mode)
 

--- a/bin/jsonfui
+++ b/bin/jsonfui
@@ -44,7 +44,7 @@ function die(e) {
 
 function openApp(data) {
   printIfNotRecursive(data);
-  app(data, ttys.stdin, process.stdout);
+  app(data, ttys.stdin, ttys.stdout);
 }
 
 function resolveFilename(filename) {

--- a/src/views/list.js
+++ b/src/views/list.js
@@ -23,6 +23,13 @@ module.exports = function listView(value, session, parent) {
     styler: new Styler(session, defaultStyle(session))
   });
 
+  list.key('o', function() {
+    var output = list.getSelectedValue().toString();
+    list.screen.destroy();
+    console.log(output);
+    process.exit(0);
+  });
+
   list.on('selectValue', function(selected) {
     if (!selected.hasChildren()) {
       return;

--- a/src/views/list.js
+++ b/src/views/list.js
@@ -23,7 +23,7 @@ module.exports = function listView(value, session, parent) {
     styler: new Styler(session, defaultStyle(session))
   });
 
-  list.key('o', function() {
+  list.key(['enter'], function() {
     var output = list.getSelectedValue().toString();
     list.screen.destroy();
     console.log(output);
@@ -36,13 +36,17 @@ module.exports = function listView(value, session, parent) {
     }
 
     var newList = listView(selected, session, parent);
-    newList.key(['escape', 'h'], function() {
+    newList.key(['left', 'escape', 'h'], function() {
       parent.remove(newList);
       parent.render();
       newList.destroy();
     });
 
     newList.focus();
+  });
+
+  list.key(['right'], function(item, selected) {
+    list.enterSelected();
   });
 
   list.key(['c', 'y'], function(item, selected) {

--- a/src/widgets/list.js
+++ b/src/widgets/list.js
@@ -115,7 +115,6 @@ function List(options) {
   };
 
   var emitSelectedValue = function(selected, index) {
-    console.error('emit selected');
     self.emit('selectValue', self.getSelectedValue());
   };
 

--- a/src/widgets/list.js
+++ b/src/widgets/list.js
@@ -115,6 +115,7 @@ function List(options) {
   };
 
   var emitSelectedValue = function(selected, index) {
+    console.error('emit selected');
     self.emit('selectValue', self.getSelectedValue());
   };
 


### PR DESCRIPTION
Continuation from discussions in #7 

This changes all of the interactive output to go to `/dev/tty` (provided by `ttys` plugin), which allows us to pipe jsonfui output into other programs.  To output and exit, press Enter.

Example:

```bash
URL="https://api.github.com/users/adrianschneider/repos"

# download, interactively explore, then write subset to disk
curl -s "$URL" | jsonfui > /tmp/dotfiles.json

```