### PR TITLE
'p' copies path of current selection to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ When the application is open, you are in a vim-style tree viewer.
 `right`, `l`: view child node  
 `<Enter>`: send current selection to stdout and exit  
 `y` or `c`: copy current value to clipboard  
+`p`: copy path to current selection to clipboard
 `-`: toggle expansion  
 `/`: search for string recursively  
 `*`: search for value under cursor  

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,6 @@ var screenView = require('./views/screen');
 var listView   = require('./views/list');
 
 module.exports = function(data, input, output) {
-  var list = listView(new Value(data, null), new Session(), screenView(input, output));
+  var list = listView(new Value(data, null), new Session(), screenView(input, output), []);
   list.focus();
 };

--- a/src/views/list.js
+++ b/src/views/list.js
@@ -6,7 +6,7 @@ var defaultStyle = require('../styles/default');
 var clipboard    = require('../clipboard')(process.platform);
 var List         = require('../widgets/list');
 
-module.exports = function listView(value, session, parent) {
+module.exports = function listView(value, session, parent, breadcrumbs) {
   var list = new List({
     parent: parent,
     tags: true,
@@ -35,7 +35,8 @@ module.exports = function listView(value, session, parent) {
       return;
     }
 
-    var newList = listView(selected, session, parent);
+    var newBreadcrumbs = breadcrumbs.concat([selected.getKey()]);
+    var newList = listView(selected, session, parent, newBreadcrumbs);
     newList.key(['left', 'escape', 'h'], function() {
       parent.remove(newList);
       parent.render();
@@ -52,6 +53,18 @@ module.exports = function listView(value, session, parent) {
   list.key(['c', 'y'], function(item, selected) {
     clipboard.copy(
       list.getSelectedValue().toString(),
+      function(){}
+    );
+  });
+
+  list.key(['p'], function() {
+    var selected = list.getSelectedValue();
+    var newBreadcrumbs = breadcrumbs.concat([selected.getKey()]);
+    var breadcrumbsString =  newBreadcrumbs.map(function(p) {
+      return typeof(p) == 'number' ? '[' + p + ']' : '["' + p + '"]';
+    }).join('')
+    clipboard.copy(
+      breadcrumbsString,
       function(){}
     );
   });


### PR DESCRIPTION
Adds a simple feature: pressing `p` copies the path of the current selection to clipboard. The path is copied as a js object literal: `obj['key'][0]['another-key'][1]`